### PR TITLE
✨ Add processInstanceId to written metrics 

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/process-engine/metrics.repository.file_system#readme",
   "dependencies": {
     "@essential-projects/errors_ts": "^1.5.0",
-    "@process-engine/metrics_api_contracts": "feature~add_process_instance_id",
+    "@process-engine/metrics_api_contracts": "^2.0.0",
     "moment": "^2.24.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/process-engine/metrics.repository.file_system#readme",
   "dependencies": {
-    "@process-engine/metrics_api_contracts": "^1.0.0",
+    "@process-engine/metrics_api_contracts": "feature~add_process_instance_id",
     "moment": "^2.24.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/process-engine/metrics.repository.file_system#readme",
   "dependencies": {
+    "@essential-projects/errors_ts": "^1.5.0",
     "@process-engine/metrics_api_contracts": "feature~add_process_instance_id",
     "moment": "^2.24.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,18 +1,25 @@
 {
   "name": "@process-engine/metrics.repository.file_system",
-  "publishConfig": {
-    "registry": "https://www.npmjs.com"
-  },
   "version": "1.2.0",
-  "description": "This repository uses the local file system to access and manipulate log files containing metrics.",
-  "license": "MIT",
+  "description": "Contains the file-system repository for the Metrics API. ",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/process-engine/metrics.repository.file_system.git"
+  },
   "author": "5Minds IT-Solutions GmbH & Co. KG",
-  "contributors": [
-    "Sebastian Meier <sebastian.meier@5minds.de>",
-    "Christian Werner <christian.werner@5minds.de>"
+  "maintainers": [
+    "Alexander Kasten <alexander.kasten@5minds.de>",
+    "Christian Werner <christian.werner@5minds.de>",
+    "René Föhring <rene.foehring@5minds.de>",
+    "Steffen Knaup <steffen.knaup@5minds.de>"
   ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/process-engine/metrics.repository.file_system/issues"
+  },
+  "homepage": "https://github.com/process-engine/metrics.repository.file_system#readme",
   "dependencies": {
     "@process-engine/metrics_api_contracts": "^1.0.0",
     "moment": "^2.24.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/metrics.repository.file_system",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Contains the file-system repository for the Metrics API. ",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/src/adapter/error_serializer.ts
+++ b/src/adapter/error_serializer.ts
@@ -1,0 +1,47 @@
+import {BaseError, isEssentialProjectsError} from '@essential-projects/errors_ts';
+
+export function serialize(error: Error | string): string {
+
+  const errorIsFromEssentialProjects = isEssentialProjectsError(error);
+  if (errorIsFromEssentialProjects) {
+    return (error as BaseError).serialize();
+  }
+
+  const errorIsString = typeof error === 'string';
+  if (errorIsString) {
+    return error as string;
+  }
+
+  return JSON.stringify(error);
+}
+
+export function deserialize(error: string): Error {
+
+  const essentialProjectsError = tryDeserializeEssentialProjectsError(error);
+
+  const errorIsFromEssentialProjects = essentialProjectsError !== undefined;
+
+  if (errorIsFromEssentialProjects) {
+    return essentialProjectsError;
+  }
+
+  return tryParse(error);
+}
+
+function tryDeserializeEssentialProjectsError(value: string): Error {
+  try {
+    return BaseError.deserialize(value);
+  } catch (error) {
+    return undefined;
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function tryParse(value: string): any {
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    // Value is not a JSON - return it as it is.
+    return value;
+  }
+}

--- a/src/adapter/file_system_adapter.ts
+++ b/src/adapter/file_system_adapter.ts
@@ -1,20 +1,15 @@
-import {Metric, MetricMeasurementPoint} from '@process-engine/metrics_api_contracts';
-
 import * as fs from 'fs';
 import * as mkdirp from 'mkdirp';
-import * as moment from 'moment';
 import * as path from 'path';
+
+import {Metric} from '@process-engine/metrics_api_contracts';
+
+import {parseMetric} from './parser/parser';
 
 export function targetExists(targetPath: string): boolean {
   return fs.existsSync(targetPath);
 }
 
-/**
- * Checks if the given path exists and creates it, if it doesn't.
- *
- * @async
- * @param targetFilePath The directory to verify.
- */
 export async function ensureDirectoryExists(targetFilePath: string): Promise<void> {
 
   // eslint-disable-next-line consistent-return
@@ -39,13 +34,6 @@ export async function ensureDirectoryExists(targetFilePath: string): Promise<voi
   });
 }
 
-/**
- * Writes the given entry to the specificed file.
- *
- * @async
- * @param targetFilePath The path to the file to write to.
- * @param entry          The entry to write into the file.
- */
 export async function writeToFile(targetFilePath: string, entry: string): Promise<void> {
 
   return new Promise<void>((resolve: Function, reject: Function): void => {
@@ -58,13 +46,6 @@ export async function writeToFile(targetFilePath: string, entry: string): Promis
   });
 }
 
-/**
- * Reads all files from the given directory and parses their content into
- * readable metrics.
- *
- * @param dirPath The path to the directory to read.
- * @returns       The parsed metrics.
- */
 export function readAndParseDirectory(dirPath: string): Array<Metric> {
 
   const fileNames = fs.readdirSync(dirPath);
@@ -80,13 +61,6 @@ export function readAndParseDirectory(dirPath: string): Array<Metric> {
   return metrics;
 }
 
-/**
- * Reads a file from the given path and parses its content into a readable
- * metrics.
- *
- * @param   filePath The path to the file to read.
- * @returns          The parsed metrics.
- */
 export function readAndParseFile(filePath: string): Array<Metric> {
 
   const fileContent = fs.readFileSync(filePath, 'utf-8');
@@ -98,65 +72,7 @@ export function readAndParseFile(filePath: string): Array<Metric> {
     return entry.length > 0;
   });
 
-  const metrics = filteredEntries.map(createMetricFromRawData);
+  const metrics = filteredEntries.map(parseMetric);
 
   return metrics;
-}
-
-/**
- * Takes a string representing a metric and parses its content into a usable
- * Metric-object.
- *
- * @param   metricRaw The string containing the unparsed metric.
- * @returns           The parsed Metric.
- */
-// tslint:disable:no-magic-numbers
-function createMetricFromRawData(metricRaw: string): Metric {
-
-  const metricRawParts = metricRaw.split(';');
-
-  const isFlowNodeInstanceMetric = metricRawParts[0] === 'FlowNodeInstance';
-
-  const metric = isFlowNodeInstanceMetric
-    ? parseFlowNodeInstanceMetric(metricRawParts)
-    : parseProcessModelMetric(metricRawParts);
-
-  return metric;
-}
-
-/**
- * Creates a Metric for a FlowNodeInstance from the given data.
- *
- * @param   rawData The data to parse into a Metric.
- * @returns         The parsed Metric.
- */
-function parseFlowNodeInstanceMetric(rawData: Array<string>): Metric {
-
-  const metric = new Metric();
-  metric.timeStamp = moment(rawData[1]);
-  metric.correlationId = rawData[2];
-  metric.processModelId = rawData[3];
-  metric.flowNodeInstanceId = rawData[4];
-  metric.flowNodeId = rawData[5];
-  metric.metricType = MetricMeasurementPoint[rawData[6]];
-  metric.processToken = JSON.parse(rawData[7]);
-
-  return metric;
-}
-
-/**
- * Creates a Metric for a ProcessModel from the given data.
- *
- * @param   rawData The data to parse into a Metric.
- * @returns         The parsed Metric.
- */
-function parseProcessModelMetric(rawData: Array<string>): Metric {
-
-  const metric = new Metric();
-  metric.timeStamp = moment(rawData[1]);
-  metric.correlationId = rawData[2];
-  metric.processModelId = rawData[3];
-  metric.metricType = MetricMeasurementPoint[rawData[7]];
-
-  return metric;
 }

--- a/src/adapter/parser/flow_node_metric_parser.ts
+++ b/src/adapter/parser/flow_node_metric_parser.ts
@@ -1,6 +1,6 @@
 import * as moment from 'moment';
 
-import {Metric, MetricMeasurementPoint} from '@atlas-engine/metrics_api.contracts';
+import {Metric, MetricMeasurementPoint} from '@process-engine/metrics_api_contracts';
 
 import * as ErrorSerializer from '../error_serializer';
 

--- a/src/adapter/parser/flow_node_metric_parser.ts
+++ b/src/adapter/parser/flow_node_metric_parser.ts
@@ -1,0 +1,60 @@
+import * as moment from 'moment';
+
+import {Metric, MetricMeasurementPoint} from '@atlas-engine/metrics_api.contracts';
+
+import * as ErrorSerializer from '../error_serializer';
+
+export function parseFlowNodeInstanceMetric(metricData: Array<string>): Metric {
+
+  const isV2 = metricData[0].endsWith('_V2');
+
+  if (isV2) {
+    return parseAsV2(metricData);
+  }
+
+  return parseAsV1(metricData);
+}
+
+/**
+ * Parses a metrics string into the old format employed by the ProcessEngine.
+ * In this version, errors were only added to the log, if any occured.
+ *
+ * @param metricAsString The metrics to parse.
+ */
+function parseAsV1(metricData: Array<string>): Metric {
+
+  const metric = new Metric();
+  metric.timeStamp = moment(metricData[1]);
+  metric.correlationId = metricData[2];
+  metric.processModelId = metricData[3];
+  metric.flowNodeInstanceId = metricData[4];
+  metric.flowNodeId = metricData[5];
+  metric.metricType = MetricMeasurementPoint[metricData[6]];
+  metric.tokenPayload = JSON.parse(metricData[7]);
+  metric.error = metricData.length === 9 ? ErrorSerializer.deserialize(metricData[8]) : undefined;
+
+  return metric;
+}
+
+/**
+ * Parses a metrics string into the format employed by the AtlasEngine.
+ * In this format, the processInstanceId was added.
+ * Also, an entry for "error" is always made, even if none occured, to ensure a consistent csv format.
+ *
+ * @param metricAsString The metrics to parse.
+ */
+function parseAsV2(metricData: Array<string>): Metric {
+
+  const metric = new Metric();
+  metric.timeStamp = moment(metricData[1]);
+  metric.correlationId = metricData[2];
+  metric.processInstanceId = metricData[3];
+  metric.processModelId = metricData[4];
+  metric.flowNodeInstanceId = metricData[5];
+  metric.flowNodeId = metricData[6];
+  metric.metricType = MetricMeasurementPoint[metricData[7]];
+  metric.tokenPayload = JSON.parse(metricData[8]);
+  metric.error = ErrorSerializer.deserialize(metricData[9]);
+
+  return metric;
+}

--- a/src/adapter/parser/flow_node_metric_parser.ts
+++ b/src/adapter/parser/flow_node_metric_parser.ts
@@ -16,7 +16,7 @@ export function parseFlowNodeInstanceMetric(metricData: Array<string>): Metric {
 }
 
 /**
- * Parses a metrics string into the old format employed by the ProcessEngine.
+ * Parses a metrics string into the v1 format employed by the ProcessEngine.
  * In this version, errors were only added to the log, if any occured.
  *
  * @param metricAsString The metrics to parse.
@@ -37,7 +37,7 @@ function parseAsV1(metricData: Array<string>): Metric {
 }
 
 /**
- * Parses a metrics string into the format employed by the AtlasEngine.
+ * Parses a metrics string into the v2 format employed by the ProcessEngine.
  * In this format, the processInstanceId was added.
  * Also, an entry for "error" is always made, even if none occured, to ensure a consistent csv format.
  *

--- a/src/adapter/parser/parser.ts
+++ b/src/adapter/parser/parser.ts
@@ -1,0 +1,17 @@
+import {Metric} from '@atlas-engine/metrics_api.contracts';
+
+import {parseFlowNodeInstanceMetric} from './flow_node_metric_parser';
+import {parseProcessModelMetric} from './process_model_metric_parser';
+
+export function parseMetric(metricRaw: string): Metric {
+
+  const metricRawParts = metricRaw.split(';');
+
+  const isFlowNodeInstanceMetric = metricRawParts[0].startsWith('FlowNodeInstance');
+
+  const metric = isFlowNodeInstanceMetric
+    ? parseFlowNodeInstanceMetric(metricRawParts)
+    : parseProcessModelMetric(metricRawParts);
+
+  return metric;
+}

--- a/src/adapter/parser/parser.ts
+++ b/src/adapter/parser/parser.ts
@@ -1,4 +1,4 @@
-import {Metric} from '@atlas-engine/metrics_api.contracts';
+import {Metric} from '@process-engine/metrics_api_contracts';
 
 import {parseFlowNodeInstanceMetric} from './flow_node_metric_parser';
 import {parseProcessModelMetric} from './process_model_metric_parser';

--- a/src/adapter/parser/process_model_metric_parser.ts
+++ b/src/adapter/parser/process_model_metric_parser.ts
@@ -1,0 +1,54 @@
+import * as moment from 'moment';
+
+import {Metric, MetricMeasurementPoint} from '@atlas-engine/metrics_api.contracts';
+
+import * as ErrorSerializer from '../error_serializer';
+
+export function parseProcessModelMetric(metricData: Array<string>): Metric {
+
+  const isV2 = metricData[0].endsWith('_V2');
+
+  if (isV2) {
+    return parseAsV2(metricData);
+  }
+
+  return parseAsV1(metricData);
+}
+
+/**
+ * Parses a metrics string into the old format employed by the ProcessEngine.
+ * In this version, errors were only added to the log, if any occured.
+ *
+ * @param metricData The metrics to parse.
+ */
+function parseAsV1(metricData: Array<string>): Metric {
+
+  const metric = new Metric();
+  metric.timeStamp = moment(metricData[1]);
+  metric.correlationId = metricData[2];
+  metric.processModelId = metricData[3];
+  metric.metricType = MetricMeasurementPoint[metricData[6]];
+  metric.error = metricData.length === 9 ? ErrorSerializer.deserialize(metricData[8]) : undefined;
+
+  return metric;
+}
+
+/**
+ * Parses a metrics string into the format employed by the AtlasEngine.
+ * In this format, the processInstanceId was added.
+ * Also, an entry for "error" is always made, even if none occured, to ensure a consistent csv format.
+ *
+ * @param metricData The metrics to parse.
+ */
+function parseAsV2(metricData: Array<string>): Metric {
+
+  const metric = new Metric();
+  metric.timeStamp = moment(metricData[1]);
+  metric.correlationId = metricData[2];
+  metric.processInstanceId = metricData[3];
+  metric.processModelId = metricData[4];
+  metric.metricType = MetricMeasurementPoint[metricData[7]];
+  metric.error = ErrorSerializer.deserialize(metricData[9]);
+
+  return metric;
+}

--- a/src/adapter/parser/process_model_metric_parser.ts
+++ b/src/adapter/parser/process_model_metric_parser.ts
@@ -1,6 +1,6 @@
 import * as moment from 'moment';
 
-import {Metric, MetricMeasurementPoint} from '@atlas-engine/metrics_api.contracts';
+import {Metric, MetricMeasurementPoint} from '@process-engine/metrics_api_contracts';
 
 import * as ErrorSerializer from '../error_serializer';
 

--- a/src/adapter/parser/process_model_metric_parser.ts
+++ b/src/adapter/parser/process_model_metric_parser.ts
@@ -16,7 +16,7 @@ export function parseProcessModelMetric(metricData: Array<string>): Metric {
 }
 
 /**
- * Parses a metrics string into the old format employed by the ProcessEngine.
+ * Parses a metrics string into the v1 format employed by the ProcessEngine.
  * In this version, errors were only added to the log, if any occured.
  *
  * @param metricData The metrics to parse.
@@ -34,7 +34,7 @@ function parseAsV1(metricData: Array<string>): Metric {
 }
 
 /**
- * Parses a metrics string into the format employed by the AtlasEngine.
+ * Parses a metrics string into the v2 format employed by the ProcessEngine.
  * In this format, the processInstanceId was added.
  * Also, an entry for "error" is always made, even if none occured, to ensure a consistent csv format.
  *

--- a/src/metrics_repository.ts
+++ b/src/metrics_repository.ts
@@ -5,6 +5,7 @@ import {
   IMetricsRepository, Metric, MetricMeasurementPoint,
 } from '@process-engine/metrics_api_contracts';
 
+import * as ErrorSerializer from './adapter/error_serializer';
 import * as FileSystemAdapter from './adapter/file_system_adapter';
 
 export class MetricsRepository implements IMetricsRepository {
@@ -47,7 +48,7 @@ export class MetricsRepository implements IMetricsRepository {
       '',
       metricType,
       '{}',
-      error.message,
+      error ? ErrorSerializer.serialize(error) : '',
     ];
 
     await this.writeMetricToFileSystem(processModelId, metricValues);
@@ -78,7 +79,7 @@ export class MetricsRepository implements IMetricsRepository {
       flowNodeId,
       metricType,
       stringyfiedToken,
-      error.message,
+      error ? ErrorSerializer.serialize(error) : '',
     ];
 
     await this.writeMetricToFileSystem(processModelId, metricValues);

--- a/src/metrics_repository.ts
+++ b/src/metrics_repository.ts
@@ -97,7 +97,7 @@ export class MetricsRepository implements IMetricsRepository {
   }
 
   private buildPath(...pathSegments: Array<string>): string {
-    return path.resolve(process.cwd(), this.config.outputPath, ...pathSegments);
+    return path.resolve(process.cwd(), this.config.output_path, ...pathSegments);
   }
 
   private buildMetricString(...args: Array<string>): string {

--- a/src/metrics_repository.ts
+++ b/src/metrics_repository.ts
@@ -2,10 +2,10 @@ import * as moment from 'moment';
 import * as path from 'path';
 
 import {
-  IMetricsRepository, Metric, MetricMeasurementPoint, ProcessToken,
+  IMetricsRepository, Metric, MetricMeasurementPoint,
 } from '@process-engine/metrics_api_contracts';
 
-import * as FileSystemAdapter from './adapter';
+import * as FileSystemAdapter from './adapter/file_system_adapter';
 
 export class MetricsRepository implements IMetricsRepository {
 
@@ -27,49 +27,64 @@ export class MetricsRepository implements IMetricsRepository {
     return metrics;
   }
 
-  public async writeMetricForProcessModel(
+  public async writeMetricForProcessInstance(
     correlationId: string,
+    processInstanceId: string,
     processModelId: string,
     metricType: MetricMeasurementPoint,
     timestamp: moment.Moment,
     error?: Error,
   ): Promise<void> {
 
-    const metricValues = ['ProcessModel', timestamp.toISOString(), correlationId, processModelId, '', '', metricType, '{}'];
+    const metricValues = [
+      // Required for versioning. This way, old logs will still be readable, because they only started with "ProcessModel".
+      'ProcessModel_V2',
+      timestamp.toISOString(),
+      correlationId,
+      processInstanceId,
+      processModelId,
+      '',
+      '',
+      metricType,
+      '{}',
+      error.message,
+    ];
 
-    if (error) {
-      const stringifiedError = JSON.stringify(error);
-      metricValues.push(stringifiedError);
-    }
-
-    await this.writeMetricToFileSystem(processModelId, ...metricValues);
+    await this.writeMetricToFileSystem(processModelId, metricValues);
   }
 
-  public async writeMetricForFlowNode(
+  public async writeMetricForFlowNodeInstance(
     correlationId: string,
+    processInstanceId: string,
     processModelId: string,
     flowNodeInstanceId: string,
     flowNodeId: string,
     metricType: MetricMeasurementPoint,
-    token: ProcessToken,
+    tokenPayload: any,
     timestamp: moment.Moment,
     error?: Error,
   ): Promise<void> {
 
-    const stringyfiedToken = JSON.stringify(token);
+    const stringyfiedToken = JSON.stringify(tokenPayload);
 
-    const metricValues =
-      ['FlowNodeInstance', timestamp.toISOString(), correlationId, processModelId, flowNodeInstanceId, flowNodeId, metricType, stringyfiedToken];
+    const metricValues = [
+      // Required for versioning. This way, old logs will still be readable, because they only started with "FlowNodeInstance".
+      'FlowNodeInstance_V2',
+      timestamp.toISOString(),
+      correlationId,
+      processInstanceId,
+      processModelId,
+      flowNodeInstanceId,
+      flowNodeId,
+      metricType,
+      stringyfiedToken,
+      error.message,
+    ];
 
-    if (error) {
-      const stringifiedError = JSON.stringify(error);
-      metricValues.push(stringifiedError);
-    }
-
-    await this.writeMetricToFileSystem(processModelId, ...metricValues);
+    await this.writeMetricToFileSystem(processModelId, metricValues);
   }
 
-  private async writeMetricToFileSystem(processModelId: string, ...metricValues: Array<string>): Promise<void> {
+  private async writeMetricToFileSystem(processModelId: string, metricValues: Array<string>): Promise<void> {
 
     const filePathWithExtension = `${processModelId}.met`;
     const targetFilePath = this.buildPath(filePathWithExtension);
@@ -81,7 +96,7 @@ export class MetricsRepository implements IMetricsRepository {
   }
 
   private buildPath(...pathSegments: Array<string>): string {
-    return path.resolve(process.cwd(), this.config.output_path, ...pathSegments);
+    return path.resolve(process.cwd(), this.config.outputPath, ...pathSegments);
   }
 
   private buildMetricString(...args: Array<string>): string {


### PR DESCRIPTION
## Changes

1. Add `processInstanceId` to written metrics
2. Only store token payloads instead of the whole ProcessToken object
3. Remove duplicated `ProcessToken` type
4. Implement support for versioning
    - This is achieved through dedicated metric parsers; one for each type
    - Each parser is able to handle different versions of a metric
    - The prefix applied to each metric will determine its version
    - The FileSystemAdapter no longer needs to know anything about the format of the metrics in order to get a parsed result
5. Add error serializer to prevent data loss during stringification of errors
6. Add author and maintainer info

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/367

PR: #3